### PR TITLE
refactor: enable critical_path argument to be used without clone

### DIFF
--- a/2020_RTSS_Shuai_Zhao/src/parallel_provider_consumer.rs
+++ b/2020_RTSS_Shuai_Zhao/src/parallel_provider_consumer.rs
@@ -42,7 +42,7 @@ pub fn get_f_consumers(
     let providers = get_providers(dag, critical_path);
     let mut f_consumers: HashMap<Vec<NodeIndex>, Vec<NodeIndex>> = HashMap::new();
     let mut non_critical_nodes: HashSet<_> = dag
-        .get_non_critical_nodes(critical_path.to_vec())
+        .get_non_critical_nodes(critical_path)
         .unwrap()
         .into_iter()
         .collect();

--- a/2020_RTSS_Shuai_Zhao/src/parallel_provider_consumer.rs
+++ b/2020_RTSS_Shuai_Zhao/src/parallel_provider_consumer.rs
@@ -17,7 +17,7 @@ pub fn get_providers(
     dag: &Graph<NodeData, i32>,
     critical_path: &[NodeIndex],
 ) -> Vec<Vec<NodeIndex>> {
-    let mut deque_critical_path: VecDeque<_> = critical_path.iter().copied().collect();
+    let mut deque_critical_path: VecDeque<NodeIndex> = critical_path.iter().copied().collect();
     let mut providers: Vec<Vec<NodeIndex>> = Vec::new();
     while !deque_critical_path.is_empty() {
         let mut provider = vec![deque_critical_path.pop_front().unwrap()];
@@ -192,8 +192,8 @@ mod tests {
 
     #[test]
     fn test_get_providers_normal() {
-        let dag = create_sample_dag();
-        let critical_path = dag.clone().get_critical_path();
+        let mut dag = create_sample_dag();
+        let critical_path = dag.get_critical_path();
         let providers = get_providers(&dag, &critical_path);
         assert_eq!(providers.len(), 4);
 
@@ -206,8 +206,8 @@ mod tests {
 
     #[test]
     fn test_get_providers_dag_not_consolidated() {
-        let dag = create_sample_dag_not_consolidated();
-        let critical_path = dag.clone().get_critical_path();
+        let mut dag = create_sample_dag_not_consolidated();
+        let critical_path = dag.get_critical_path();
         let providers = get_providers(&dag, &critical_path);
         assert_eq!(providers.len(), 3);
 
@@ -219,7 +219,7 @@ mod tests {
     #[test]
     fn test_get_f_consumers_normal() {
         let mut dag = create_sample_dag();
-        let critical_path = dag.clone().get_critical_path();
+        let critical_path = dag.get_critical_path();
         let providers = get_providers(&dag, &critical_path);
         let f_consumers = get_f_consumers(&mut dag, &critical_path);
 
@@ -256,7 +256,7 @@ mod tests {
     #[test]
     fn test_get_g_consumers_normal() {
         let dag = create_sample_dag();
-        let critical_path = dag.clone().get_critical_path();
+        let critical_path = dag.get_critical_path();
         let providers = get_providers(&dag, critical_path.clone());
         let g_consumers = get_g_consumers(dag, critical_path);
 

--- a/lib/src/graph_extension.rs
+++ b/lib/src/graph_extension.rs
@@ -33,7 +33,7 @@ pub trait GraphExtension {
     fn remove_dummy_source_node(&mut self);
     fn remove_dummy_sink_node(&mut self);
     fn get_critical_path(&mut self) -> Vec<NodeIndex>;
-    fn get_non_critical_nodes(&mut self, critical_path: Vec<NodeIndex>) -> Option<Vec<NodeIndex>>;
+    fn get_non_critical_nodes(&mut self, critical_path: &[NodeIndex]) -> Option<Vec<NodeIndex>>;
     fn get_source_nodes(&self) -> Vec<NodeIndex>;
     fn get_sink_nodes(&self) -> Vec<NodeIndex>;
     fn get_volume(&self) -> i32;
@@ -266,7 +266,7 @@ impl GraphExtension for Graph<NodeData, i32> {
         critical_path[0].clone()
     }
 
-    fn get_non_critical_nodes(&mut self, critical_path: Vec<NodeIndex>) -> Option<Vec<NodeIndex>> {
+    fn get_non_critical_nodes(&mut self, critical_path: &[NodeIndex]) -> Option<Vec<NodeIndex>> {
         let mut no_critical_path_nodes = Vec::new();
         for node in self.node_indices() {
             if !critical_path.contains(&node) {
@@ -546,7 +546,7 @@ mod tests {
         dag.add_edge(n2, n4, 1);
 
         let critical_path = dag.get_critical_path();
-        let no_critical_path_nodes = dag.get_non_critical_nodes(critical_path).unwrap();
+        let no_critical_path_nodes = dag.get_non_critical_nodes(&critical_path).unwrap();
         assert_eq!(no_critical_path_nodes.len(), 2);
 
         assert_eq!(no_critical_path_nodes, &[n1, n3]);
@@ -556,7 +556,7 @@ mod tests {
     fn test_get_non_critical_nodes_no_exist() {
         let mut dag = Graph::<NodeData, i32>::new();
         let critical_path = dag.get_critical_path();
-        let no_critical_path_nodes = dag.get_non_critical_nodes(critical_path);
+        let no_critical_path_nodes = dag.get_non_critical_nodes(&critical_path);
         assert_eq!(no_critical_path_nodes, None);
     }
 

--- a/lib/src/graph_extension.rs
+++ b/lib/src/graph_extension.rs
@@ -33,7 +33,7 @@ pub trait GraphExtension {
     fn remove_dummy_source_node(&mut self);
     fn remove_dummy_sink_node(&mut self);
     fn get_critical_path(&mut self) -> Vec<NodeIndex>;
-    fn get_non_critical_nodes(&mut self, critical_path: &[NodeIndex]) -> Option<Vec<NodeIndex>>;
+    fn get_non_critical_nodes(&self, critical_path: &[NodeIndex]) -> Option<Vec<NodeIndex>>;
     fn get_source_nodes(&self) -> Vec<NodeIndex>;
     fn get_sink_nodes(&self) -> Vec<NodeIndex>;
     fn get_volume(&self) -> i32;
@@ -266,7 +266,7 @@ impl GraphExtension for Graph<NodeData, i32> {
         critical_path[0].clone()
     }
 
-    fn get_non_critical_nodes(&mut self, critical_path: &[NodeIndex]) -> Option<Vec<NodeIndex>> {
+    fn get_non_critical_nodes(&self, critical_path: &[NodeIndex]) -> Option<Vec<NodeIndex>> {
         let mut no_critical_path_nodes = Vec::new();
         for node in self.node_indices() {
             if !critical_path.contains(&node) {


### PR DESCRIPTION
- By making the argument a reference, the possibility of using a clone was reduced.
- Addition of a function to check if a node can be retrieved even if it has independent nodes.
- PR mainly for #23 