### PR TITLE
refactor: chang NodeData in the allocate argument to a reference so that the same NodeData can be allocated to multiple cores without clone().

### DIFF
--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -30,7 +30,7 @@ impl Default for Core {
 
 ///return bool since "panic!" would terminate
 impl Core {
-    pub fn allocate(&mut self, node_data: NodeData) -> bool {
+    pub fn allocate(&mut self, node_data: &NodeData) -> bool {
         if !self.is_idle {
             warn!("Core is already allocated to a node");
             return false;
@@ -83,7 +83,7 @@ mod tests {
     #[test]
     fn test_core_allocate_normal() {
         let mut core = Core::default();
-        core.allocate(create_node(0, "execution_time", 10));
+        core.allocate(&create_node(0, "execution_time", 10));
         assert!(!core.is_idle);
         assert_eq!(core.processing_node, Some(0));
         assert_eq!(core.remain_proc_time, 10);
@@ -92,20 +92,20 @@ mod tests {
     #[test]
     fn test_core_allocate_already_allocated() {
         let mut core = Core::default();
-        core.allocate(create_node(0, "execution_time", 10));
-        assert!(!core.allocate(create_node(1, "execution_time", 10)));
+        core.allocate(&create_node(0, "execution_time", 10));
+        assert!(!core.allocate(&create_node(1, "execution_time", 10)));
     }
 
     #[test]
     fn test_core_allocate_node_no_has_execution_time() {
         let mut core = Core::default();
-        assert!(!core.allocate(create_node(0, "no_execution_time", 10)));
+        assert!(!core.allocate(&create_node(0, "no_execution_time", 10)));
     }
 
     #[test]
     fn test_core_process_normal() {
         let mut core = Core::default();
-        core.allocate(create_node(0, "execution_time", 10));
+        core.allocate(&create_node(0, "execution_time", 10));
         assert_eq!(core.process(), Continue);
         assert_eq!(core.remain_proc_time, 9);
         core.process();
@@ -121,7 +121,7 @@ mod tests {
     #[test]
     fn test_core_process_when_finished() {
         let mut core = Core::default();
-        core.allocate(create_node(0, "execution_time", 2));
+        core.allocate(&create_node(0, "execution_time", 2));
         core.process();
         assert_eq!(core.process(), Done(NodeIndex::new(0)));
         assert!(core.is_idle);

--- a/lib/src/fixed_priority_scheduler.rs
+++ b/lib/src/fixed_priority_scheduler.rs
@@ -77,7 +77,7 @@ pub fn fixed_priority_scheduler(
         //Assign the highest priority task first to the first idle core found.
         while let Some(core_index) = processor.get_idle_core_index() {
             if let Some(task) = ready_queue.pop_front() {
-                processor.allocate(core_index, dag[task].clone());
+                processor.allocate(core_index, &dag[task]);
                 execution_order.push(task);
             } else {
                 break;

--- a/lib/src/homogeneous.rs
+++ b/lib/src/homogeneous.rs
@@ -12,7 +12,7 @@ impl ProcessorBase for HomogeneousProcessor {
         }
     }
 
-    fn allocate(&mut self, core_id: usize, node_data: NodeData) -> bool {
+    fn allocate(&mut self, core_id: usize, node_data: &NodeData) -> bool {
         self.cores[core_id].allocate(node_data)
     }
 
@@ -62,18 +62,18 @@ mod tests {
     fn test_processor_allocate_normal() {
         let mut homogeneous_processor = HomogeneousProcessor::new(2);
 
-        assert!(homogeneous_processor.allocate(0, create_node(0, "execution_time", 2)));
+        assert!(homogeneous_processor.allocate(0, &create_node(0, "execution_time", 2)));
         assert!(!homogeneous_processor.cores[0].is_idle);
         assert!(homogeneous_processor.cores[1].is_idle);
-        assert!(homogeneous_processor.allocate(1, create_node(1, "execution_time", 2)));
+        assert!(homogeneous_processor.allocate(1, &create_node(1, "execution_time", 2)));
     }
 
     #[test]
     fn test_processor_allocate_same_core() {
         let mut homogeneous_processor = HomogeneousProcessor::new(2);
-        homogeneous_processor.allocate(0, create_node(0, "execution_time", 2));
+        homogeneous_processor.allocate(0, &create_node(0, "execution_time", 2));
 
-        assert!(!homogeneous_processor.allocate(0, create_node(0, "execution_time", 2)));
+        assert!(!homogeneous_processor.allocate(0, &create_node(0, "execution_time", 2)));
     }
 
     #[test]
@@ -81,14 +81,14 @@ mod tests {
     fn test_processor_allocate_no_exist_core() {
         let mut homogeneous_processor = HomogeneousProcessor::new(2);
 
-        homogeneous_processor.allocate(2, create_node(0, "execution_time", 2));
+        homogeneous_processor.allocate(2, &create_node(0, "execution_time", 2));
     }
 
     #[test]
     fn test_processor_process_normal() {
         let mut homogeneous_processor = HomogeneousProcessor::new(2);
-        homogeneous_processor.allocate(0, create_node(0, "execution_time", 2));
-        homogeneous_processor.allocate(1, create_node(0, "execution_time", 3));
+        homogeneous_processor.allocate(0, &create_node(0, "execution_time", 2));
+        homogeneous_processor.allocate(1, &create_node(0, "execution_time", 3));
 
         assert_eq!(
             homogeneous_processor.process(),
@@ -101,7 +101,7 @@ mod tests {
     #[test]
     fn test_processor_process_when_one_core_no_allocated() {
         let mut homogeneous_processor = HomogeneousProcessor::new(2);
-        homogeneous_processor.allocate(0, create_node(0, "execution_time", 2));
+        homogeneous_processor.allocate(0, &create_node(0, "execution_time", 2));
 
         assert_eq!(
             homogeneous_processor.process(),
@@ -135,11 +135,11 @@ mod tests {
 
         let n1 = create_node(0, "execution_time", 2);
 
-        homogeneous_processor.allocate(0, n1.clone());
+        homogeneous_processor.allocate(0, &n1);
 
         assert_eq!(homogeneous_processor.get_idle_core_index(), Some(1));
 
-        homogeneous_processor.allocate(1, n1);
+        homogeneous_processor.allocate(1, &n1);
 
         assert_eq!(homogeneous_processor.get_idle_core_index(), None);
     }

--- a/lib/src/processor.rs
+++ b/lib/src/processor.rs
@@ -2,7 +2,7 @@ use crate::{core::*, graph_extension::NodeData};
 
 pub trait ProcessorBase {
     fn new(num_cores: usize) -> Self;
-    fn allocate(&mut self, core_id: usize, node_data: NodeData) -> bool;
+    fn allocate(&mut self, core_id: usize, node_data: &NodeData) -> bool;
     fn process(&mut self) -> Vec<ProcessResult>;
     fn get_number_of_cores(&self) -> usize;
     fn get_idle_core_index(&self) -> Option<usize>;


### PR DESCRIPTION
- NodeData in the argument of allocate is changed to reference
 - Allocate the same NodeData to multiple cores without cloning
- gang sched, etc.