### PR TITLE
fix: align dag to avoid bugs and to apply to dag_set

### DIFF
--- a/2021_RTCSA_dynfed/src/dynfed.rs
+++ b/2021_RTCSA_dynfed/src/dynfed.rs
@@ -34,6 +34,7 @@ where
     let volume = dag.get_volume();
     let end_to_end_deadline = dag.get_end_to_end_deadline().unwrap();
     let mut minimum_cores = (volume as f32 / end_to_end_deadline as f32).ceil() as usize;
+    scheduler.set_dag(dag);
     scheduler.set_processor(&T::new(minimum_cores));
     let (mut schedule_length, mut execution_order) = scheduler.schedule();
 
@@ -85,7 +86,10 @@ mod tests {
     #[test]
     fn test_calculate_minimum_cores_and_execution_order_normal() {
         let mut dag = create_sample_dag();
-        let mut scheduler = FixedPriorityScheduler::new(&dag, &HomogeneousProcessor::new(1));
+        let mut scheduler = FixedPriorityScheduler::new(
+            &Graph::<NodeData, i32>::new(),
+            &HomogeneousProcessor::new(1),
+        );
         let (minimum_cores, execution_order) =
             calculate_minimum_cores_and_execution_order(&mut dag, &mut scheduler);
 

--- a/lib/src/fixed_priority_scheduler.rs
+++ b/lib/src/fixed_priority_scheduler.rs
@@ -29,6 +29,10 @@ where
         }
     }
 
+    fn set_dag(&mut self, dag: &Graph<NodeData, i32>) {
+        self.dag = dag.clone();
+    }
+
     fn set_processor(&mut self, processor: &T) {
         self.processor = processor.clone();
     }
@@ -193,7 +197,19 @@ mod tests {
     }
 
     #[test]
-    fn test_fixed_priority_scheduler_update_processor() {
+    fn test_fixed_priority_scheduler_set_dag() {
+        let mut dag = Graph::<NodeData, i32>::new();
+        dag.add_node(create_node(0, "execution_time", 0));
+        let processor = HomogeneousProcessor::new(1);
+        let mut scheduler = FixedPriorityScheduler::new(&dag, &processor);
+        assert_eq!(scheduler.dag.node_count(), 1);
+        assert_eq!(scheduler.processor.get_number_of_cores(), 1);
+        scheduler.set_dag(&Graph::<NodeData, i32>::new());
+        assert_eq!(scheduler.dag.node_count(), 0);
+    }
+
+    #[test]
+    fn test_fixed_priority_scheduler_set_processor() {
         let mut dag = Graph::<NodeData, i32>::new();
         dag.add_node(create_node(0, "execution_time", 0));
         let processor = HomogeneousProcessor::new(1);

--- a/lib/src/scheduler.rs
+++ b/lib/src/scheduler.rs
@@ -5,6 +5,7 @@ where
     T: ProcessorBase + Clone,
 {
     fn new(dag: &Graph<NodeData, i32>, processor: &T) -> Self;
+    fn set_dag(&mut self, dag: &Graph<NodeData, i32>);
     fn set_processor(&mut self, processor: &T);
     fn schedule(&mut self) -> (i32, Vec<NodeIndex>);
 }


### PR DESCRIPTION
- Implement set_dag in sched.
 - To not allow the target DAG to be different in the precomputation phase.
 - To allow the precomputation phase to be applied to dag_set.