### PR TITLE
perf: change return value to NodeData to determine which DAG it belongs.

### DIFF
--- a/lib/src/fixed_priority_scheduler.rs
+++ b/lib/src/fixed_priority_scheduler.rs
@@ -125,8 +125,8 @@ where
             let finish_nodes: Vec<NodeIndex> = process_result
                 .iter()
                 .filter_map(|result| {
-                    if let ProcessResult::Done(id) = result {
-                        Some(*id)
+                    if let ProcessResult::Done(node_data) = result {
+                        Some(NodeIndex::new(node_data.id as usize))
                     } else {
                         None
                     }

--- a/lib/src/graph_extension.rs
+++ b/lib/src/graph_extension.rs
@@ -45,6 +45,7 @@ pub trait GraphExtension {
     fn get_anc_nodes(&self, node_i: NodeIndex) -> Option<Vec<NodeIndex>>;
     fn get_des_nodes(&self, node_i: NodeIndex) -> Option<Vec<NodeIndex>>;
     fn get_parallel_process_nodes(&self, node_i: NodeIndex) -> Option<Vec<NodeIndex>>;
+    fn set_dag_id(&mut self, dag_id: usize);
     fn add_node_with_id_consistency(&mut self, node: NodeData) -> NodeIndex;
 }
 
@@ -476,6 +477,12 @@ impl GraphExtension for Graph<NodeData, i32> {
             None
         } else {
             Some(parallel_process_nodes)
+        }
+    }
+
+    fn set_dag_id(&mut self, dag_id: usize) {
+        for node_i in self.node_indices() {
+            self.add_param(node_i, "dag_id", dag_id as i32);
         }
     }
 
@@ -1059,6 +1066,16 @@ mod tests {
         let n0 = dag.add_node(create_node(0, "parallel_process", 0));
 
         assert_eq!(dag.get_parallel_process_nodes(n0), None);
+    }
+
+    #[test]
+    fn test_set_dag_id_normal() {
+        let mut dag = Graph::<NodeData, i32>::new();
+        dag.set_dag_id(0);
+
+        for node_i in dag.node_indices() {
+            assert_eq!(dag[node_i].params["dag_id"], 0);
+        }
     }
 
     #[test]

--- a/lib/src/graph_extension.rs
+++ b/lib/src/graph_extension.rs
@@ -482,6 +482,9 @@ impl GraphExtension for Graph<NodeData, i32> {
     }
 
     fn get_dag_id(&self) -> usize {
+        if self.node_indices().count() == 0 {
+            panic!("Error: dag_id does not exist. Please use set_dag_id(dag_id: usize)");
+        }
         self[NodeIndex::new(0)].params["dag_id"] as usize
     }
 

--- a/lib/src/graph_extension.rs
+++ b/lib/src/graph_extension.rs
@@ -45,6 +45,7 @@ pub trait GraphExtension {
     fn get_anc_nodes(&self, node_i: NodeIndex) -> Option<Vec<NodeIndex>>;
     fn get_des_nodes(&self, node_i: NodeIndex) -> Option<Vec<NodeIndex>>;
     fn get_parallel_process_nodes(&self, node_i: NodeIndex) -> Option<Vec<NodeIndex>>;
+    fn get_dag_id(&self) -> usize;
     fn set_dag_id(&mut self, dag_id: usize);
     fn add_node_with_id_consistency(&mut self, node: NodeData) -> NodeIndex;
 }
@@ -480,7 +481,14 @@ impl GraphExtension for Graph<NodeData, i32> {
         }
     }
 
+    fn get_dag_id(&self) -> usize {
+        self[NodeIndex::new(0)].params["dag_id"] as usize
+    }
+
     fn set_dag_id(&mut self, dag_id: usize) {
+        if self.node_indices().count() == 0 {
+            panic!("No node found.");
+        }
         for node_i in self.node_indices() {
             self.add_param(node_i, "dag_id", dag_id as i32);
         }
@@ -1069,13 +1077,36 @@ mod tests {
     }
 
     #[test]
+    fn test_get_dag_id_normal() {
+        let mut dag = Graph::<NodeData, i32>::new();
+        dag.add_node(create_node(0, "dag_id", 0));
+        assert_eq!(dag.get_dag_id(), 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_get_dag_id_no_exist_node() {
+        let dag = Graph::<NodeData, i32>::new();
+        dag.get_dag_id();
+    }
+
+    #[test]
     fn test_set_dag_id_normal() {
         let mut dag = Graph::<NodeData, i32>::new();
+        dag.add_node(create_node(0, "execution_time", 0));
+        dag.add_node(create_node(1, "execution_time", 0));
         dag.set_dag_id(0);
 
         for node_i in dag.node_indices() {
             assert_eq!(dag[node_i].params["dag_id"], 0);
         }
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_set_dag_id_no_exist_node() {
+        let mut dag = Graph::<NodeData, i32>::new();
+        dag.set_dag_id(0);
     }
 
     #[test]

--- a/lib/src/homogeneous.rs
+++ b/lib/src/homogeneous.rs
@@ -39,7 +39,6 @@ impl ProcessorBase for HomogeneousProcessor {
 mod tests {
     use super::*;
     use crate::{core::ProcessResult, graph_extension::NodeData, processor::ProcessorBase};
-    use petgraph::graph::NodeIndex;
     use std::collections::HashMap;
 
     fn create_node(id: i32, key: &str, value: i32) -> NodeData {
@@ -110,7 +109,10 @@ mod tests {
         );
         assert_eq!(
             homogeneous_processor.process(),
-            vec![ProcessResult::Done(NodeIndex::new(0)), ProcessResult::Idle]
+            vec![
+                ProcessResult::Done(create_node(0, "execution_time", 2)),
+                ProcessResult::Idle
+            ]
         );
         assert_eq!(
             homogeneous_processor.process(),

--- a/lib/src/util.rs
+++ b/lib/src/util.rs
@@ -13,10 +13,6 @@ pub fn get_hyper_period(dag_set: &Vec<Graph<NodeData, i32>>) -> i32 {
     hyper_period
 }
 
-pub fn get_dag_id(node_data: &NodeData) -> usize {
-    node_data.params["dag_id"] as usize
-}
-
 #[cfg(test)]
 
 mod tests {
@@ -42,13 +38,5 @@ mod tests {
             create_dag(40),
         ];
         assert_eq!(get_hyper_period(&dag_set), 120);
-    }
-
-    #[test]
-    fn test_get_dag_id_normal() {
-        let mut params = HashMap::new();
-        params.insert("dag_id".to_owned(), 1);
-        let node_data = NodeData { id: 0, params };
-        assert_eq!(get_dag_id(&node_data), 1);
     }
 }

--- a/lib/src/util.rs
+++ b/lib/src/util.rs
@@ -13,6 +13,10 @@ pub fn get_hyper_period(dag_set: &Vec<Graph<NodeData, i32>>) -> i32 {
     hyper_period
 }
 
+pub fn get_dag_id(node_data: &NodeData) -> usize {
+    node_data.params["dag_id"] as usize
+}
+
 #[cfg(test)]
 
 mod tests {
@@ -38,5 +42,13 @@ mod tests {
             create_dag(40),
         ];
         assert_eq!(get_hyper_period(&dag_set), 120);
+    }
+
+    #[test]
+    fn test_get_dag_id_normal() {
+        let mut params = HashMap::new();
+        params.insert("dag_id".to_owned(), 1);
+        let node_data = NodeData { id: 0, params };
+        assert_eq!(get_dag_id(&node_data), 1);
     }
 }


### PR DESCRIPTION
- Changed the return value to NodeData to make it easier to see which DAG it belongs to.
- PR for #26 