### PR TITLE
feat: add dag_id to NodeLog for DAGSet

### DIFF
--- a/lib/src/fixed_priority_scheduler.rs
+++ b/lib/src/fixed_priority_scheduler.rs
@@ -42,8 +42,7 @@ where
         self.dag = dag.clone();
         self.node_logs = dag
             .node_indices()
-            .enumerate()
-            .map(|(dag_id, node_id)| NodeLog::new(dag_id, node_id.index()))
+            .map(|node_index| NodeLog::new(0, dag[node_index].id as usize))
             .collect();
     }
 

--- a/lib/src/fixed_priority_scheduler.rs
+++ b/lib/src/fixed_priority_scheduler.rs
@@ -406,5 +406,11 @@ mod tests {
         assert_eq!(fixed_priority_scheduler.node_logs[1].node_id, 1);
         assert_eq!(fixed_priority_scheduler.node_logs[1].start_time, 52);
         assert_eq!(fixed_priority_scheduler.node_logs[1].finish_time, 92);
+
+        assert_eq!(fixed_priority_scheduler.node_logs[2].core_id, 1);
+        assert_eq!(fixed_priority_scheduler.node_logs[2].dag_id, 0);
+        assert_eq!(fixed_priority_scheduler.node_logs[2].node_id, 2);
+        assert_eq!(fixed_priority_scheduler.node_logs[2].start_time, 62);
+        assert_eq!(fixed_priority_scheduler.node_logs[2].finish_time, 74);
     }
 }

--- a/lib/src/fixed_priority_scheduler.rs
+++ b/lib/src/fixed_priority_scheduler.rs
@@ -30,14 +30,22 @@ where
         Self {
             dag: dag.clone(),
             processor: processor.clone(),
-            node_logs: (0..dag.node_count()).map(NodeLog::new).collect(),
+            node_logs: dag
+                .node_indices()
+                .enumerate()
+                .map(|(dag_id, node_id)| NodeLog::new(dag_id, node_id.index()))
+                .collect(),
             processor_log: ProcessorLog::new(processor.get_number_of_cores()),
         }
     }
 
     fn set_dag(&mut self, dag: &Graph<NodeData, i32>) {
         self.dag = dag.clone();
-        self.node_logs = (0..dag.node_count()).map(NodeLog::new).collect();
+        self.node_logs = dag
+            .node_indices()
+            .enumerate()
+            .map(|(dag_id, node_id)| NodeLog::new(dag_id, node_id.index()))
+            .collect();
     }
 
     fn set_processor(&mut self, processor: &T) {
@@ -389,6 +397,7 @@ mod tests {
         );
 
         assert_eq!(fixed_priority_scheduler.node_logs[0].core_id, 0);
+        assert_eq!(fixed_priority_scheduler.node_logs[0].dag_id, 0);
         assert_eq!(fixed_priority_scheduler.node_logs[0].node_id, 0);
         assert_eq!(fixed_priority_scheduler.node_logs[0].start_time, 0);
         assert_eq!(fixed_priority_scheduler.node_logs[0].finish_time, 52);

--- a/lib/src/fixed_priority_scheduler.rs
+++ b/lib/src/fixed_priority_scheduler.rs
@@ -32,8 +32,10 @@ where
             processor: processor.clone(),
             node_logs: dag
                 .node_indices()
-                .enumerate()
-                .map(|(dag_id, node_id)| NodeLog::new(dag_id, node_id.index()))
+                .map(|node_index| {
+                    let node = dag.node_weight(node_index).unwrap();
+                    NodeLog::new(0, node.id as usize)
+                })
                 .collect(),
             processor_log: ProcessorLog::new(processor.get_number_of_cores()),
         }
@@ -401,5 +403,11 @@ mod tests {
         assert_eq!(fixed_priority_scheduler.node_logs[0].node_id, 0);
         assert_eq!(fixed_priority_scheduler.node_logs[0].start_time, 0);
         assert_eq!(fixed_priority_scheduler.node_logs[0].finish_time, 52);
+
+        assert_eq!(fixed_priority_scheduler.node_logs[1].core_id, 0);
+        assert_eq!(fixed_priority_scheduler.node_logs[1].dag_id, 0);
+        assert_eq!(fixed_priority_scheduler.node_logs[1].node_id, 1);
+        assert_eq!(fixed_priority_scheduler.node_logs[1].start_time, 52);
+        assert_eq!(fixed_priority_scheduler.node_logs[1].finish_time, 92);
     }
 }

--- a/lib/src/fixed_priority_scheduler.rs
+++ b/lib/src/fixed_priority_scheduler.rs
@@ -406,11 +406,5 @@ mod tests {
         assert_eq!(fixed_priority_scheduler.node_logs[1].node_id, 1);
         assert_eq!(fixed_priority_scheduler.node_logs[1].start_time, 52);
         assert_eq!(fixed_priority_scheduler.node_logs[1].finish_time, 92);
-
-        assert_eq!(fixed_priority_scheduler.node_logs[2].core_id, 1);
-        assert_eq!(fixed_priority_scheduler.node_logs[2].dag_id, 0);
-        assert_eq!(fixed_priority_scheduler.node_logs[2].node_id, 2);
-        assert_eq!(fixed_priority_scheduler.node_logs[2].start_time, 62);
-        assert_eq!(fixed_priority_scheduler.node_logs[2].finish_time, 74);
     }
 }

--- a/lib/src/fixed_priority_scheduler.rs
+++ b/lib/src/fixed_priority_scheduler.rs
@@ -32,10 +32,7 @@ where
             processor: processor.clone(),
             node_logs: dag
                 .node_indices()
-                .map(|node_index| {
-                    let node = dag.node_weight(node_index).unwrap();
-                    NodeLog::new(0, node.id as usize)
-                })
+                .map(|node_index| NodeLog::new(0, dag[node_index].id as usize))
                 .collect(),
             processor_log: ProcessorLog::new(processor.get_number_of_cores()),
         }

--- a/lib/src/output_log.rs
+++ b/lib/src/output_log.rs
@@ -184,7 +184,7 @@ mod tests {
     #[test]
     fn test_dump_node_logs_to_yaml() {
         let file_path = create_scheduler_log_yaml_file("tests", "tests3");
-        let node_log = NodeLog::new(0);
+        let node_log = NodeLog::new(0, 0);
         let node_logs = vec![node_log];
 
         dump_node_logs_to_yaml(&file_path, node_logs);
@@ -193,6 +193,7 @@ mod tests {
         let yaml_node_logs: NodeLogs = serde_yaml::from_str(&file_contents).unwrap();
 
         assert_eq!(yaml_node_logs.node_logs[0].core_id, 0);
+        assert_eq!(yaml_node_logs.node_logs[0].dag_id, 0);
         assert_eq!(yaml_node_logs.node_logs[0].node_id, 0);
         assert_eq!(yaml_node_logs.node_logs[0].start_time, 0);
         assert_eq!(yaml_node_logs.node_logs[0].finish_time, 0);

--- a/lib/src/scheduler.rs
+++ b/lib/src/scheduler.rs
@@ -23,6 +23,7 @@ pub trait DAGSetSchedulerBase<T: ProcessorBase + Clone> {
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub struct NodeLog {
     pub core_id: usize,
+    pub dag_id: usize,
     pub node_id: usize,
     pub start_time: i32,
     pub finish_time: i32,
@@ -32,6 +33,7 @@ impl NodeLog {
     pub fn new(node_id: usize) -> Self {
         Self {
             core_id: Default::default(),
+            dag_id: Default::default(),
             node_id,
             start_time: Default::default(),
             finish_time: Default::default(),

--- a/lib/src/scheduler.rs
+++ b/lib/src/scheduler.rs
@@ -30,10 +30,10 @@ pub struct NodeLog {
 }
 
 impl NodeLog {
-    pub fn new(node_id: usize) -> Self {
+    pub fn new(dag_id: usize, node_id: usize) -> Self {
         Self {
             core_id: Default::default(),
-            dag_id: Default::default(),
+            dag_id,
             node_id,
             start_time: Default::default(),
             finish_time: Default::default(),

--- a/lib/src/scheduler.rs
+++ b/lib/src/scheduler.rs
@@ -23,7 +23,7 @@ pub trait DAGSetSchedulerBase<T: ProcessorBase + Clone> {
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub struct NodeLog {
     pub core_id: usize,
-    pub dag_id: usize,
+    pub dag_id: usize, // Used to distinguish DAGs when the scheduler input is DAGSet
     pub node_id: usize,
     pub start_time: i32,
     pub finish_time: i32,


### PR DESCRIPTION
- Add dag_id to NodeLog for DAGSet.
- Fixed priority scheduler coordination.