### PR TITLE
feat: implement log structure to output logs to file

### DIFF
--- a/2021_RTCSA_dynfed/src/dynfed.rs
+++ b/2021_RTCSA_dynfed/src/dynfed.rs
@@ -130,6 +130,9 @@ where
     dag_set: Vec<Graph<NodeData, i32>>,
     processor: HomogeneousProcessor,
     scheduler: T,
+    pub dag_set_log: Vec<DAGLog>,
+    pub node_logs: Vec<Vec<NodeLog>>,
+    pub processor_log: ProcessorLog,
 }
 
 impl<T> DAGSetSchedulerBase<HomogeneousProcessor> for DynamicFederatedScheduler<T>
@@ -138,9 +141,21 @@ where
 {
     fn new(dag_set: Vec<Graph<NodeData, i32>>, processor: HomogeneousProcessor) -> Self {
         Self {
-            dag_set,
+            dag_set: dag_set.clone(),
             processor: processor.clone(),
             scheduler: T::new(&Graph::<NodeData, i32>::new(), &processor),
+            dag_set_log: (0..dag_set.len()).map(DAGLog::new).collect(),
+            node_logs: dag_set
+                .iter()
+                .enumerate()
+                .map(|(dag_id, dag)| {
+                    dag.node_indices()
+                        .enumerate()
+                        .map(|(node_id, _)| NodeLog::new(dag_id, node_id))
+                        .collect()
+                })
+                .collect(),
+            processor_log: ProcessorLog::new(processor.get_number_of_cores()),
         }
     }
 

--- a/2021_RTCSA_dynfed/src/dynfed.rs
+++ b/2021_RTCSA_dynfed/src/dynfed.rs
@@ -131,7 +131,7 @@ where
     processor: HomogeneousProcessor,
     scheduler: T,
     pub dag_set_log: Vec<DAGLog>,
-    pub node_logs: Vec<Vec<NodeLog>>,
+    pub node_logs: Vec<Vec<NodeLog>>, //node_logs[dag_id][node_id]
     pub processor_log: ProcessorLog,
 }
 

--- a/2021_RTCSA_dynfed/src/dynfed.rs
+++ b/2021_RTCSA_dynfed/src/dynfed.rs
@@ -276,9 +276,7 @@ where
             }
         }
 
-        let schedule_length = current_time;
-        self.processor_log
-            .calculate_cores_utilization(schedule_length);
+        self.processor_log.calculate_cores_utilization(current_time);
 
         self.processor_log.calculate_average_utilization();
 

--- a/2021_RTCSA_dynfed/src/dynfed.rs
+++ b/2021_RTCSA_dynfed/src/dynfed.rs
@@ -190,7 +190,7 @@ where
                     .filter(|dag| current_time == dag.get_head_offset())
                     .for_each(|dag| {
                         ready_dag_queue.push_back(dag.clone());
-                        self.dag_set_log[dag.get_dag_id()].released_time = current_time;
+                        self.dag_set_log[dag.get_dag_id()].release_time = current_time;
                     });
                 head_offsets.pop_front();
             }
@@ -357,7 +357,7 @@ mod tests {
         assert_eq!(time, 103);
 
         assert_eq!(dynfed.dag_set_log[1].dag_id, 1);
-        assert_eq!(dynfed.dag_set_log[1].released_time, 0);
+        assert_eq!(dynfed.dag_set_log[1].release_time, 0);
         assert_eq!(dynfed.dag_set_log[1].start_time, 50);
         assert_eq!(dynfed.dag_set_log[1].finish_time, 103);
         assert_eq!(dynfed.dag_set_log[1].minimum_cores, 2);

--- a/lib/src/scheduler.rs
+++ b/lib/src/scheduler.rs
@@ -25,6 +25,18 @@ pub struct DAGLog {
     pub dag_id: usize,
     pub start_time: i32,
     pub finish_time: i32,
+    pub minimum_cores: i32,
+}
+
+impl DAGLog {
+    pub fn new(dag_id: usize) -> Self {
+        Self {
+            dag_id,
+            start_time: Default::default(),
+            finish_time: Default::default(),
+            minimum_cores: Default::default(),
+        }
+    }
 }
 
 #[derive(Clone, Default, Serialize, Deserialize)]

--- a/lib/src/scheduler.rs
+++ b/lib/src/scheduler.rs
@@ -102,7 +102,7 @@ impl ProcessorLog {
     }
 }
 
-#[derive(Clone, Default, Serialize, Deserialize, Debug)]
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub struct CoreLog {
     pub core_id: usize,
     pub total_proc_time: i32,

--- a/lib/src/scheduler.rs
+++ b/lib/src/scheduler.rs
@@ -23,7 +23,7 @@ pub trait DAGSetSchedulerBase<T: ProcessorBase + Clone> {
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub struct DAGLog {
     pub dag_id: usize,
-    pub released_time: i32,
+    pub release_time: i32,
     pub start_time: i32,
     pub finish_time: i32,
     pub minimum_cores: i32,
@@ -33,7 +33,7 @@ impl DAGLog {
     pub fn new(dag_id: usize) -> Self {
         Self {
             dag_id,
-            released_time: Default::default(),
+            release_time: Default::default(),
             start_time: Default::default(),
             finish_time: Default::default(),
             minimum_cores: Default::default(),

--- a/lib/src/scheduler.rs
+++ b/lib/src/scheduler.rs
@@ -21,6 +21,13 @@ pub trait DAGSetSchedulerBase<T: ProcessorBase + Clone> {
 }
 
 #[derive(Clone, Default, Serialize, Deserialize)]
+pub struct DAGLog {
+    pub dag_id: usize,
+    pub start_time: i32,
+    pub finish_time: i32,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub struct NodeLog {
     pub core_id: usize,
     pub dag_id: usize,

--- a/lib/src/scheduler.rs
+++ b/lib/src/scheduler.rs
@@ -23,6 +23,7 @@ pub trait DAGSetSchedulerBase<T: ProcessorBase + Clone> {
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub struct DAGLog {
     pub dag_id: usize,
+    pub released_time: i32,
     pub start_time: i32,
     pub finish_time: i32,
     pub minimum_cores: i32,
@@ -32,6 +33,7 @@ impl DAGLog {
     pub fn new(dag_id: usize) -> Self {
         Self {
             dag_id,
+            released_time: Default::default(),
             start_time: Default::default(),
             finish_time: Default::default(),
             minimum_cores: Default::default(),
@@ -100,7 +102,7 @@ impl ProcessorLog {
     }
 }
 
-#[derive(Clone, Default, Serialize, Deserialize)]
+#[derive(Clone, Default, Serialize, Deserialize, Debug)]
 pub struct CoreLog {
     pub core_id: usize,
     pub total_proc_time: i32,


### PR DESCRIPTION
- Implement log structure to output logs to file.
- pub dag_set_log: Vec<DAGLog>
 -- Minimum number of cores required, offset, start and finish time
- pub node_logs: Vec<Vec<NodeLog>>
 -- Maintains information on nodes for each DAG.
 -- node_logs[dag_id][node_id]
- pub processor_log: ProcessorLog
 -- Same as #51 
- For PR #58