### PR TITLE
feat: write preempt and resume log

### DIFF
--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -70,6 +70,7 @@ impl Core {
             node_data
                 .params
                 .insert("execution_time".to_string(), self.remain_proc_time);
+            node_data.params.insert("is_suspend".to_string(), 1);
             self.is_idle = true;
             self.processing_node = None;
             self.remain_proc_time = 0;

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -62,7 +62,7 @@ impl Core {
         Continue
     }
 
-    pub fn suspend_execution(&mut self) -> Option<NodeData> {
+    pub fn preempt_execution(&mut self) -> Option<NodeData> {
         if self.is_idle {
             None
         } else {
@@ -70,7 +70,7 @@ impl Core {
             node_data
                 .params
                 .insert("execution_time".to_string(), self.remain_proc_time);
-            node_data.params.insert("is_suspend".to_string(), 1);
+            node_data.params.insert("is_preempt".to_string(), 1);
             self.is_idle = true;
             self.processing_node = None;
             self.remain_proc_time = 0;

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -62,7 +62,7 @@ impl Core {
         Continue
     }
 
-    pub fn preempt_execution(&mut self) -> Option<NodeData> {
+    pub fn preempt(&mut self) -> Option<NodeData> {
         if self.is_idle {
             None
         } else {
@@ -70,7 +70,7 @@ impl Core {
             node_data
                 .params
                 .insert("execution_time".to_string(), self.remain_proc_time);
-            node_data.params.insert("is_preempt".to_string(), 1);
+            node_data.params.insert("is_preempted".to_string(), 1);
             self.is_idle = true;
             self.processing_node = None;
             self.remain_proc_time = 0;

--- a/lib/src/dag_set_scheduler.rs
+++ b/lib/src/dag_set_scheduler.rs
@@ -126,7 +126,7 @@ pub trait DAGSetSchedulerBase<T: ProcessorBase + Clone> {
         self.get_processor_mut()
             .allocate_specific_core(core_i, node);
         let current_time = self.get_current_time();
-        if node.params.contains_key("is_preempt") {
+        if node.params.contains_key("is_preempted") {
             self.get_log_mut().write_job_event(
                 node,
                 core_i,

--- a/lib/src/dag_set_scheduler.rs
+++ b/lib/src/dag_set_scheduler.rs
@@ -126,7 +126,7 @@ pub trait DAGSetSchedulerBase<T: ProcessorBase + Clone> {
         self.get_processor_mut()
             .allocate_specific_core(core_i, node);
         let current_time = self.get_current_time();
-        if node.params.contains_key("is_suspend") {
+        if node.params.contains_key("is_preempt") {
             self.get_log_mut().write_job_event(
                 node,
                 core_i,
@@ -258,12 +258,12 @@ pub trait DAGSetSchedulerBase<T: ProcessorBase + Clone> {
                     // Preempt the node with the lowest priority
                     let current_time = self.get_current_time();
                     let processor = self.get_processor_mut();
-                    // Suspended node data
-                    let suspended_node_data = processor.suspend_execution(core_i).unwrap();
+                    // Preempted node data
+                    let preempted_node_data = processor.preempt_execution(core_i).unwrap();
                     self.get_log_mut().write_job_event(
-                        &suspended_node_data,
+                        &preempted_node_data,
                         core_i,
-                        (managers[suspended_node_data.get_params_value("dag_id") as usize]
+                        (managers[preempted_node_data.get_params_value("dag_id") as usize]
                             .get_release_count() as usize)
                             - 1,
                         JobEventTimes::PreemptedTime(current_time),
@@ -276,9 +276,9 @@ pub trait DAGSetSchedulerBase<T: ProcessorBase + Clone> {
                         managers[allocate_node_data.get_params_value("dag_id") as usize]
                             .get_release_count() as usize,
                     );
-                    // Insert the suspended node into the ready queue
+                    // Insert the preempted node into the ready queue
                     ready_queue.insert(NodeDataWrapper {
-                        node_data: suspended_node_data,
+                        node_data: preempted_node_data,
                     });
                 } else {
                     break; // No core is idle and can not preempt. Exit the loop.

--- a/lib/src/dag_set_scheduler.rs
+++ b/lib/src/dag_set_scheduler.rs
@@ -258,6 +258,7 @@ pub trait DAGSetSchedulerBase<T: ProcessorBase + Clone> {
                     // Preempt the node with the lowest priority
                     let current_time = self.get_current_time();
                     let processor = self.get_processor_mut();
+                    // Suspended node data
                     let suspended_node_data = processor.suspend_execution(core_i).unwrap();
                     self.get_log_mut().write_job_event(
                         &suspended_node_data,
@@ -267,6 +268,7 @@ pub trait DAGSetSchedulerBase<T: ProcessorBase + Clone> {
                             - 1,
                         JobEventTimes::PreemptedTime(current_time),
                     );
+                    // Allocate the preempted node
                     let allocate_node_data = &ready_queue.pop_first().unwrap().convert_node_data();
                     self.allocate_node(
                         allocate_node_data,
@@ -274,6 +276,7 @@ pub trait DAGSetSchedulerBase<T: ProcessorBase + Clone> {
                         managers[allocate_node_data.get_params_value("dag_id") as usize]
                             .get_release_count() as usize,
                     );
+                    // Insert the suspended node into the ready queue
                     ready_queue.insert(NodeDataWrapper {
                         node_data: suspended_node_data,
                     });

--- a/lib/src/dag_set_scheduler.rs
+++ b/lib/src/dag_set_scheduler.rs
@@ -246,7 +246,7 @@ pub trait DAGSetSchedulerBase<T: ProcessorBase + Clone> {
                     let current_time = self.get_current_time();
                     let processor = self.get_processor_mut();
                     // Preempted node data
-                    let preempted_node_data = processor.preempt_execution(core_i).unwrap();
+                    let preempted_node_data = processor.preempt(core_i).unwrap();
                     self.get_log_mut().write_job_event(
                         &preempted_node_data,
                         core_i,

--- a/lib/src/dag_set_scheduler.rs
+++ b/lib/src/dag_set_scheduler.rs
@@ -122,25 +122,12 @@ pub trait DAGSetSchedulerBase<T: ProcessorBase + Clone> {
         ready_nodes
     }
 
-    fn allocate_node(&mut self, node: &NodeData, core_i: usize, job_i: usize) {
+    fn allocate_node(&mut self, node_data: &NodeData, core_id: usize, job_id: usize) {
         self.get_processor_mut()
-            .allocate_specific_core(core_i, node);
+            .allocate_specific_core(core_id, node_data);
         let current_time = self.get_current_time();
-        if node.params.contains_key("is_preempted") {
-            self.get_log_mut().write_job_event(
-                node,
-                core_i,
-                job_i - 1,
-                JobEventTimes::ResumeTime(current_time),
-            )
-        } else {
-            self.get_log_mut().write_job_event(
-                node,
-                core_i,
-                job_i - 1,
-                JobEventTimes::StartTime(current_time),
-            )
-        }
+        self.get_log_mut()
+            .write_allocating_job(node_data, core_id, job_id, current_time)
     }
 
     fn process_unit_time(&mut self) -> Vec<ProcessResult> {

--- a/lib/src/global_edf_scheduler.rs
+++ b/lib/src/global_edf_scheduler.rs
@@ -272,34 +272,36 @@ mod tests {
         assert_eq!(dag_set_log["finish_time"][0].as_i64().unwrap(), 80);
         assert_eq!(dag_set_log["response_time"][0].as_i64().unwrap(), 80);
 
-        // TODO: Check after implementing log writing functionality
-        /*// Check the value of node_set_logs
+        // Check the value of node_set_logs
         let node_set_logs = &yaml_doc["node_set_logs"][0];
         assert_eq!(node_set_logs[0]["core_id"].as_i64().unwrap(), 1);
         assert_eq!(node_set_logs[0]["dag_id"].as_i64().unwrap(), 0);
         assert_eq!(node_set_logs[0]["node_id"].as_i64().unwrap(), 0);
         // start_time
         assert_eq!(node_set_logs[0]["event_time"].as_str().unwrap(), "0");
+        // preempt_time
+        assert_eq!(node_set_logs[1]["event_time"].as_str().unwrap(), "5");
+        // resume_time
+        assert_eq!(node_set_logs[2]["event_time"].as_str().unwrap(), "10");
         // finish_time
-        assert_eq!(node_set_logs[1]["event_time"].as_str().unwrap(), "10");
+        assert_eq!(node_set_logs[3]["event_time"].as_str().unwrap(), "15");
 
         // Check the value of processor_log
         let processor_log = &yaml_doc["processor_log"];
         assert_eq!(
             processor_log["average_utilization"].as_f64().unwrap(),
-            0.26666668
+            0.73333335
         );
         assert_eq!(
             processor_log["variance_utilization"].as_f64().unwrap(),
-            0.06055556
+            0.017777776
         );
 
         // Check the value of core_logs
         let core_logs = &processor_log["core_logs"][0];
         assert_eq!(core_logs["core_id"].as_i64().unwrap(), 0);
-        assert_eq!(core_logs["total_proc_time"].as_i64().unwrap(), 200);
-        assert_eq!(core_logs["utilization"].as_f64().unwrap(), 0.6666667);
-        */
+        assert_eq!(core_logs["total_proc_time"].as_i64().unwrap(), 130);
+        assert_eq!(core_logs["utilization"].as_f64().unwrap(), 0.8666667);
 
         remove_file(file_path).unwrap();
     }

--- a/lib/src/homogeneous.rs
+++ b/lib/src/homogeneous.rs
@@ -39,7 +39,7 @@ impl ProcessorBase for HomogeneousProcessor {
     }
 
     fn preempt_execution(&mut self, core_id: usize) -> Option<NodeData> {
-        self.cores[core_id].preempt_execution()
+        self.cores[core_id].preempt()
     }
 
     fn get_max_value_and_index(&self, key: &str) -> Option<(i32, usize)> {

--- a/lib/src/homogeneous.rs
+++ b/lib/src/homogeneous.rs
@@ -38,8 +38,8 @@ impl ProcessorBase for HomogeneousProcessor {
         None
     }
 
-    fn suspend_execution(&mut self, core_id: usize) -> Option<NodeData> {
-        self.cores[core_id].suspend_execution()
+    fn preempt_execution(&mut self, core_id: usize) -> Option<NodeData> {
+        self.cores[core_id].preempt_execution()
     }
 
     fn get_max_value_and_index(&self, key: &str) -> Option<(i32, usize)> {
@@ -217,7 +217,7 @@ mod tests {
     }
 
     #[test]
-    fn test_processor_suspend_execution_normal() {
+    fn test_processor_preempt_execution_normal() {
         let mut homogeneous_processor = HomogeneousProcessor::new(2);
 
         let n0 = create_node(0, "execution_time", 2);
@@ -228,16 +228,16 @@ mod tests {
         homogeneous_processor.allocate_specific_core(1, &n1);
         homogeneous_processor.process();
 
-        assert_eq!(homogeneous_processor.suspend_execution(0), None);
+        assert_eq!(homogeneous_processor.preempt_execution(0), None);
 
-        n1 = homogeneous_processor.suspend_execution(1).unwrap();
+        n1 = homogeneous_processor.preempt_execution(1).unwrap();
 
         assert_eq!(n1.params["execution_time"], 1);
 
         homogeneous_processor.allocate_specific_core(0, &n1);
         homogeneous_processor.process();
 
-        assert_eq!(homogeneous_processor.suspend_execution(0), None);
+        assert_eq!(homogeneous_processor.preempt_execution(0), None);
     }
 
     #[test]
@@ -253,7 +253,7 @@ mod tests {
             Some((11, 1))
         );
 
-        n1 = homogeneous_processor.suspend_execution(1).unwrap();
+        n1 = homogeneous_processor.preempt_execution(1).unwrap();
         assert_eq!(
             homogeneous_processor.get_max_value_and_index("execution_time"),
             Some((10, 0))

--- a/lib/src/homogeneous.rs
+++ b/lib/src/homogeneous.rs
@@ -38,7 +38,7 @@ impl ProcessorBase for HomogeneousProcessor {
         None
     }
 
-    fn preempt_execution(&mut self, core_id: usize) -> Option<NodeData> {
+    fn preempt(&mut self, core_id: usize) -> Option<NodeData> {
         self.cores[core_id].preempt()
     }
 
@@ -228,16 +228,16 @@ mod tests {
         homogeneous_processor.allocate_specific_core(1, &n1);
         homogeneous_processor.process();
 
-        assert_eq!(homogeneous_processor.preempt_execution(0), None);
+        assert_eq!(homogeneous_processor.preempt(0), None);
 
-        n1 = homogeneous_processor.preempt_execution(1).unwrap();
+        n1 = homogeneous_processor.preempt(1).unwrap();
 
         assert_eq!(n1.params["execution_time"], 1);
 
         homogeneous_processor.allocate_specific_core(0, &n1);
         homogeneous_processor.process();
 
-        assert_eq!(homogeneous_processor.preempt_execution(0), None);
+        assert_eq!(homogeneous_processor.preempt(0), None);
     }
 
     #[test]
@@ -253,7 +253,7 @@ mod tests {
             Some((11, 1))
         );
 
-        n1 = homogeneous_processor.preempt_execution(1).unwrap();
+        n1 = homogeneous_processor.preempt(1).unwrap();
         assert_eq!(
             homogeneous_processor.get_max_value_and_index("execution_time"),
             Some((10, 0))

--- a/lib/src/log.rs
+++ b/lib/src/log.rs
@@ -323,6 +323,30 @@ impl DAGSetSchedulerLog {
         self.dag_set_log[dag_id].finish_time.push(finish_time);
     }
 
+    pub fn write_allocating_job(
+        &mut self,
+        node_data: &NodeData,
+        core_id: usize,
+        job_id: usize,
+        current_time: i32,
+    ) {
+        if node_data.params.contains_key("is_preempted") {
+            self.write_job_event(
+                node_data,
+                core_id,
+                job_id - 1,
+                JobEventTimes::ResumeTime(current_time),
+            )
+        } else {
+            self.write_job_event(
+                node_data,
+                core_id,
+                job_id - 1,
+                JobEventTimes::StartTime(current_time),
+            )
+        }
+    }
+
     pub fn write_job_event(
         &mut self,
         node_data: &NodeData,

--- a/lib/src/log.rs
+++ b/lib/src/log.rs
@@ -323,21 +323,15 @@ impl DAGSetSchedulerLog {
         self.dag_set_log[dag_id].finish_time.push(finish_time);
     }
 
-    pub fn write_allocating_job(
+    pub fn write_job_event(
         &mut self,
         node_data: &NodeData,
         core_id: usize,
         job_id: usize,
-        current_time: i32,
+        event_time: JobEventTimes,
     ) {
         let dag_id = node_data.get_params_value("dag_id") as usize;
-        let job_log = JobLog::new(
-            core_id,
-            dag_id,
-            node_data.id as usize,
-            job_id,
-            JobEventTimes::StartTime(current_time),
-        );
+        let job_log = JobLog::new(core_id, dag_id, node_data.id as usize, job_id, event_time);
         self.node_set_logs[dag_id].push(job_log);
     }
 
@@ -345,24 +339,6 @@ impl DAGSetSchedulerLog {
         for core_index in core_indices {
             self.processor_log.core_logs[*core_index].total_proc_time += 1;
         }
-    }
-
-    pub fn write_finishing_job(
-        &mut self,
-        node_data: &NodeData,
-        core_id: usize,
-        job_id: usize,
-        finish_time: i32,
-    ) {
-        let dag_id = node_data.get_params_value("dag_id") as usize;
-        let job_log = JobLog::new(
-            core_id,
-            dag_id,
-            node_data.id as usize,
-            job_id,
-            JobEventTimes::FinishTime(finish_time),
-        );
-        self.node_set_logs[dag_id].push(job_log);
     }
 
     pub fn calculate_response_time(&mut self) {

--- a/lib/src/processor.rs
+++ b/lib/src/processor.rs
@@ -7,6 +7,6 @@ pub trait ProcessorBase {
     fn get_number_of_cores(&self) -> usize;
     fn get_idle_core_index(&self) -> Option<usize>;
     fn get_idle_core_num(&self) -> usize;
-    fn suspend_execution(&mut self, core_id: usize) -> Option<NodeData>;
+    fn preempt_execution(&mut self, core_id: usize) -> Option<NodeData>;
     fn get_max_value_and_index(&self, key: &str) -> Option<(i32, usize)>;
 }

--- a/lib/src/processor.rs
+++ b/lib/src/processor.rs
@@ -7,6 +7,6 @@ pub trait ProcessorBase {
     fn get_number_of_cores(&self) -> usize;
     fn get_idle_core_index(&self) -> Option<usize>;
     fn get_idle_core_num(&self) -> usize;
-    fn preempt_execution(&mut self, core_id: usize) -> Option<NodeData>;
+    fn preempt(&mut self, core_id: usize) -> Option<NodeData>;
     fn get_max_value_and_index(&self, key: &str) -> Option<(i32, usize)>;
 }


### PR DESCRIPTION
## Description

- Implement logging during preemptive and resume
- Combined two functions for logging nodes into `write_job_event()`
- Add "is_suspend" param to node when suspending.
- Determine if the node has "is_suspend" or not to determine if it is a resume or not.

## Related links

None.

## Pre-review checklist for the PR author

- [x] I've confirmed the [self-checklist](https://docs.google.com/spreadsheets/d/1p5KMcm752iCySHJz0xL1qf6fcLDKprbo/edit#gid=863618628).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
