### PR TITLE
fix: dag_creator

### DIFF
--- a/2020_RTSS_cpc_model_based_algorithm/src/main.rs
+++ b/2020_RTSS_cpc_model_based_algorithm/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
     if arg.ratio_deadline_to_period > 1.0 {
         panic!("ratio_deadline_to_period must be less than or equal to 1.0");
     }
-    let mut dag = create_dag_from_yaml(&arg.dag_file_path);
+    let mut dag = create_dag_from_yaml(&arg.dag_file_path, false);
     let homogeneous_processor = HomogeneousProcessor::new(arg.number_of_cores);
     prioritization_cpc_model::assign_priority_to_cpc_model(&mut dag);
     let mut fixed_priority_scheduler = FixedPriorityScheduler::new(&dag, &homogeneous_processor);

--- a/lib/src/dag_creator.rs
+++ b/lib/src/dag_creator.rs
@@ -485,7 +485,7 @@ mod tests {
         assert_eq!(
             dag[first_node].params.get("Weight").unwrap(),
             &410000,
-            "first node weight is expected to be 409999"
+            "first node weight is expected to be 410000"
         );
         assert_eq!(
             dag[last_node].params.get("Weight").unwrap(),

--- a/lib/src/dag_creator.rs
+++ b/lib/src/dag_creator.rs
@@ -42,7 +42,7 @@ fn get_minimum_decimal_places(yaml: &Yaml) -> usize {
     minimum_decimal_places
 }
 
-fn is_decimal(dir_path: &str) -> bool {
+fn is_contains_decimal_in_yamls(dir_path: &str) -> bool {
     let file_path_list = get_yaml_paths_from_dir(dir_path);
     for file_path in file_path_list {
         let yaml_docs = load_yaml(&file_path);
@@ -78,17 +78,14 @@ fn is_decimal(dir_path: &str) -> bool {
 /// let node_id = dag[first_node].id;
 /// let edge_weight = dag[first_edge];
 /// ```
-pub fn create_dag_from_yaml(file_path: &str, other_decimal: bool) -> Graph<NodeData, i32> {
+pub fn create_dag_from_yaml(file_path: &str, is_other_decimal: bool) -> Graph<NodeData, i32> {
     let yaml_docs = load_yaml(file_path);
     let yaml_doc = &yaml_docs[0];
     let mut int_conversion_factor =
         10f32.powi(get_minimum_decimal_places(yaml_doc).try_into().unwrap()) as i32;
-    if other_decimal {
+    if is_other_decimal || int_conversion_factor > 1 && int_conversion_factor <= 100000 {
         int_conversion_factor = 100000;
-    } else if int_conversion_factor == 1 {
-    } else if int_conversion_factor <= 100000 {
-        int_conversion_factor = 100000;
-    } else {
+    } else if int_conversion_factor > 100000 {
         panic!("The number of decimal places is too large. Please reduce the number of decimal places to 5 or less.");
     }
 
@@ -197,11 +194,11 @@ fn get_yaml_paths_from_dir(dir_path: &str) -> Vec<String> {
 /// ```
 pub fn create_dag_set_from_dir(dir_path: &str) -> Vec<Graph<NodeData, i32>> {
     let file_path_list = get_yaml_paths_from_dir(dir_path);
-    let other_decimal = is_decimal(dir_path);
+    let is_contains_decimal = is_contains_decimal_in_yamls(dir_path);
     let mut dag_set: Vec<Graph<NodeData, i32>> = Vec::new();
 
     for (dag_id, file_path) in file_path_list.iter().enumerate() {
-        let mut dag = create_dag_from_yaml(file_path, other_decimal);
+        let mut dag = create_dag_from_yaml(file_path, is_contains_decimal);
         dag.set_dag_param("dag_id", dag_id as i32);
         dag_set.push(dag);
     }

--- a/lib/src/dag_creator.rs
+++ b/lib/src/dag_creator.rs
@@ -163,7 +163,7 @@ fn get_yaml_paths_from_dir(dir_path: &str) -> Vec<String> {
     file_path_list
 }
 
-/// load yaml files and return a dag_set (dag list)
+/// load yaml files and return a DAGSet (dag list)
 ///
 /// # Arguments
 ///

--- a/lib/tests/sample_dags/multiple_float_yaml/dag_0.yaml
+++ b/lib/tests/sample_dags/multiple_float_yaml/dag_0.yaml
@@ -1,0 +1,16 @@
+directed: true
+graph: {}
+links:
+- Transfer: 1
+  communication_time: 1
+  source: 0
+  target: 1
+multigraph: false
+nodes:
+- Weight: 4
+  execution_time: 3.1
+  id: 0
+- Weight: 1
+  end_to_end_deadline: 225
+  execution_time: 43
+  id: 1

--- a/lib/tests/sample_dags/multiple_float_yaml/dag_1.yaml
+++ b/lib/tests/sample_dags/multiple_float_yaml/dag_1.yaml
@@ -1,0 +1,16 @@
+directed: true
+graph: {}
+links:
+- Transfer: 1
+  communication_time: 1
+  source: 0
+  target: 1
+multigraph: false
+nodes:
+- Weight: 4
+  execution_time: 3.01
+  id: 0
+- Weight: 1
+  end_to_end_deadline: 225
+  execution_time: 43
+  id: 1

--- a/lib/tests/sample_dags/multiple_int_float_yaml/dag_0.yaml
+++ b/lib/tests/sample_dags/multiple_int_float_yaml/dag_0.yaml
@@ -1,0 +1,16 @@
+directed: true
+graph: {}
+links:
+- Transfer: 1
+  communication_time: 1
+  source: 0
+  target: 1
+multigraph: false
+nodes:
+- Weight: 4
+  execution_time: 3
+  id: 0
+- Weight: 1
+  end_to_end_deadline: 225
+  execution_time: 43
+  id: 1

--- a/lib/tests/sample_dags/multiple_int_float_yaml/dag_1.yaml
+++ b/lib/tests/sample_dags/multiple_int_float_yaml/dag_1.yaml
@@ -1,0 +1,16 @@
+directed: true
+graph: {}
+links:
+- Transfer: 1
+  communication_time: 1
+  source: 0
+  target: 1
+multigraph: false
+nodes:
+- Weight: 4
+  execution_time: 3.1
+  id: 0
+- Weight: 1
+  end_to_end_deadline: 225
+  execution_time: 43
+  id: 1


### PR DESCRIPTION
## Description

- Fixed a bug in DAGSet creation that the scale was wrong when ints and floats were mixed or when the number of digits in the float was different.
- Added a function to determine if there is a decimal point in a group of yaml to be read.
- Added judgment of whether or not to scale to the argument of the DAG creation function.
- In the DAGSet creation function, if there is a decimal point in the yaml group, scale all DAGs.
- if exist_other_float_dag || int_conversion_factor > 1
  - The second part of the above is for the case where the function is used by itself.
 

## Related links

None.

## Pre-review checklist for the PR author

- [x] I've confirmed the [self-checklist](https://docs.google.com/spreadsheets/d/1p5KMcm752iCySHJz0xL1qf6fcLDKprbo/edit#gid=863618628).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
