### PR TITLE
fix: cal_response

### DIFF
--- a/lib/src/fixed_priority_scheduler.rs
+++ b/lib/src/fixed_priority_scheduler.rs
@@ -1,6 +1,7 @@
 use crate::{
     dag_scheduler::DAGSchedulerBase, graph_extension::NodeData, log::*, processor::ProcessorBase,
 };
+use log::warn;
 use petgraph::Graph;
 use std::collections::VecDeque;
 
@@ -53,7 +54,7 @@ where
     fn sort_ready_queue(ready_queue: &mut VecDeque<NodeData>) {
         ready_queue.make_contiguous().sort_by_key(|node| {
             *node.params.get("priority").unwrap_or_else(|| {
-                eprintln!(
+                warn!(
                     "Warning: 'priority' parameter not found for node {:?}",
                     node
                 );

--- a/lib/src/log.rs
+++ b/lib/src/log.rs
@@ -110,8 +110,10 @@ impl DAGLog {
     }
 
     pub fn calculate_response_time(&mut self) {
+        // Unequal lengths indicate that the DAG was not completed within the hyper_period, and deadline miss occurred.
         if self.release_time.len() != self.finish_time.len() {
-            self.finish_time.push(999999);
+            // Mark as a deadline miss by maximizing the response time.
+            self.finish_time.push(std::i32::MAX);
         }
         self.response_time = self
             .release_time

--- a/lib/src/log.rs
+++ b/lib/src/log.rs
@@ -110,6 +110,9 @@ impl DAGLog {
     }
 
     pub fn calculate_response_time(&mut self) {
+        if self.release_time.len() != self.finish_time.len() {
+            self.finish_time.push(999999);
+        }
         self.response_time = self
             .release_time
             .iter()


### PR DESCRIPTION
## Description

- Changed to take response time when DAG is not completed within the simulator period
- When not completed, `std::i32::MAX` is recorded as the finish time, intentionally maximizing the response time.
- Therefore, judged to cause a deadline miss.

## Related links

None.

## Pre-review checklist for the PR author

- [x] I've confirmed the [self-checklist](https://docs.google.com/spreadsheets/d/1p5KMcm752iCySHJz0xL1qf6fcLDKprbo/edit#gid=863618628).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
